### PR TITLE
Update repo metadata for transfer to PDLPorters + use GitHub issues

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -46,9 +46,9 @@ WriteMakefile(
     },
     META_ADD => {
         resources => {
-            homepage          => 'http://github.com/drzowie/PDL-Transform-Color',
-            repository        => 'git://github.com/drzowie/PDL-Transform-Color.git',
-            bugtracker        => 'http://rt.cpan.org/Public/Dist/Display.html?Name=PDL-Transform-Color'
+            homepage          => 'http://github.com/PDLPorters/PDL-Transform-Color',
+            repository        => 'git://github.com/PDLPorters/PDL-Transform-Color.git',
+            bugtracker        => 'http://github.com/PDLPorters/PDL-Transform-Color/issues'
         }
     },  
 


### PR DESCRIPTION
This is not strictly necessary because GitHub sets up redirects, but
good to get out of the way now.
